### PR TITLE
feat: DefaultValueStrategy

### DIFF
--- a/docs/configuration/default-value-strategy.md
+++ b/docs/configuration/default-value-strategy.md
@@ -1,0 +1,61 @@
+# Default Value Strategy
+
+Controls whether data class constructor parameters with default values should use their Kotlin default or be replaced with a generated fixture value.
+
+The default is `DefaultValueStrategy.UseDefault`, which preserves Kotlin default values.
+
+## Variants
+
+### `UseDefault`
+
+Uses the Kotlin default constructor value for optional parameters.
+
+```kotlin
+data class User(val role: String = "guest")
+
+val user = some<User> {
+    defaultValueStrategy = DefaultValueStrategy.UseDefault
+}
+
+user.role // "guest"
+```
+
+This is the default strategy and ensures backward compatibility.
+
+### `Generate`
+
+Generates a value for optional parameters through the resolver chain, ignoring the Kotlin default value.
+
+```kotlin
+data class User(val role: String = "guest")
+
+val user = some<User> {
+    defaultValueStrategy = DefaultValueStrategy.Generate
+}
+
+user.role // "a-random-string"
+```
+
+Use this strategy when you need fully populated objects even for classes that declare defaults.
+
+## Custom Property Factories
+
+Custom property factories always take precedence over the default value strategy.
+
+```kotlin
+data class User(val role: String = "guest")
+
+val user = some<User> {
+    defaultValueStrategy = DefaultValueStrategy.Generate
+    property(User::role) { "admin" }
+}
+
+user.role // "admin"
+```
+
+## Summary table
+
+| Strategy | Behavior |
+|----------|----------|
+| `UseDefault` | Uses Kotlin default values for optional parameters (default) |
+| `Generate` | Generates fixture values for optional parameters |

--- a/docs/configuration/default-value-strategy.md
+++ b/docs/configuration/default-value-strategy.md
@@ -20,7 +20,7 @@ val user = some<User> {
 user.role // "guest"
 ```
 
-This is the default strategy and ensures backward compatibility.
+This is the default strategy.
 
 ### `Generate`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -71,6 +71,7 @@ val stillNeverNull: Person = baseSome()
 | `nullableStrategy` | `NullableStrategy.NullOnCircularReference` | Emits `null` for nullable circular references | [NullableStrategy](nullable-strategy.md) |
 | `stringStrategy` | `StringStrategy.Random()` | Random lowercase alphabetic strings | [StringStrategy](string-strategy.md) |
 | `collectionStrategy` | `CollectionStrategy()` | Collections with 1 to 5 elements | [CollectionStrategy](collection-strategy.md) |
+| `defaultValueStrategy` | `DefaultValueStrategy.UseDefault` | Uses Kotlin defaults for optional parameters | [DefaultValueStrategy](default-value-strategy.md) |
 | `seed` | `null` | Uses non-deterministic `Random.Default` | — |
 
 ## Reproducible Data
@@ -109,6 +110,14 @@ val user = some<User> {
 ```kotlin
 val order = some<Order> {
     collectionStrategy = CollectionStrategy(2..2)
+}
+```
+
+### Generate All Optional Values
+
+```kotlin
+val user = some<User> {
+    defaultValueStrategy = DefaultValueStrategy.Generate
 }
 ```
 

--- a/src/main/kotlin/dev/appoutlet/some/config/DefaultValueStrategy.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/DefaultValueStrategy.kt
@@ -1,0 +1,38 @@
+package dev.appoutlet.some.config
+
+/**
+ * Strategy for handling data class constructor parameters with default values.
+ *
+ * Determines whether the resolver should use the Kotlin default value or generate a new value.
+ *
+ * ## Available Strategies
+ *
+ * - [UseDefault] – (Default) Uses the Kotlin default value for optional parameters.
+ * - [Generate] – Generates a value for optional parameters through the resolver chain.
+ *
+ * ## Example Usage
+ *
+ * ```kotlin
+ * // Default behavior: use Kotlin defaults
+ * some { defaultValueStrategy = DefaultValueStrategy.UseDefault }
+ *
+ * // Always generate values, even for parameters with defaults
+ * some { defaultValueStrategy = DefaultValueStrategy.Generate }
+ * ```
+ */
+sealed interface DefaultValueStrategy {
+    /**
+     * Uses the Kotlin default constructor value for optional parameters.
+     *
+     * This is the default behavior and preserves backward compatibility.
+     */
+    data object UseDefault : DefaultValueStrategy
+
+    /**
+     * Generates a value for optional parameters through the resolver chain.
+     *
+     * Use this strategy when you want fully populated objects regardless of whether
+     * they have default values in their constructor.
+     */
+    data object Generate : DefaultValueStrategy
+}

--- a/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
@@ -52,6 +52,7 @@ import kotlin.reflect.KClass
  * @param seed Seed for reproducible random generation. When `null`, [Random.Default] is used.
  * @param typeFactories Custom type factories keyed by the exact class they override. These are resolved before all
  * built-in resolvers.
+ * @param defaultValueStrategy Strategy for handling data class constructor defaults.
  * @param propertyFactories Custom property factories keyed by owning class and constructor parameter name. These are
  * applied by [DataClassResolver] while constructing model objects.
  */
@@ -59,6 +60,7 @@ data class SomeConfig(
     val nullableStrategy: NullableStrategy = NullableStrategy.NullOnCircularReference,
     val stringStrategy: StringStrategy = StringStrategy.Random(),
     val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    val defaultValueStrategy: DefaultValueStrategy = DefaultValueStrategy.UseDefault,
     val seed: Long? = null,
     val typeFactories: Map<KClass<*>, FixtureContext.() -> Any?> = emptyMap(),
     val propertyFactories: Map<Pair<KClass<*>, String>, FixtureContext.() -> Any?> = emptyMap(),
@@ -75,6 +77,7 @@ data class SomeConfig(
         nullableStrategy = this@SomeConfig.nullableStrategy
         stringStrategy = this@SomeConfig.stringStrategy
         collectionStrategy = this@SomeConfig.collectionStrategy
+        defaultValueStrategy = this@SomeConfig.defaultValueStrategy
         seed = this@SomeConfig.seed
         populateTypeFactories(this@SomeConfig.typeFactories)
         populatePropertyFactories(this@SomeConfig.propertyFactories)
@@ -92,7 +95,14 @@ data class SomeConfig(
      */
     fun buildResolvers(random: Random = buildRandom()): List<TypeResolver> {
         return listOf(
-            CustomTypeFactoryResolver(typeFactories, random, nullableStrategy, stringStrategy, collectionStrategy),
+            CustomTypeFactoryResolver(
+                typeFactories = typeFactories,
+                random = random,
+                nullableStrategy = nullableStrategy,
+                stringStrategy = stringStrategy,
+                collectionStrategy = collectionStrategy,
+                defaultValueStrategy = defaultValueStrategy
+            ),
             NullableResolver(nullableStrategy, random),
             ObjectResolver(),
             EnumResolver(random),
@@ -126,7 +136,8 @@ data class SomeConfig(
                 random = random,
                 nullableStrategy = nullableStrategy,
                 stringStrategy = stringStrategy,
-                collectionStrategy = collectionStrategy
+                collectionStrategy = collectionStrategy,
+                defaultValueStrategy = defaultValueStrategy,
             )
         )
     }

--- a/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
@@ -101,7 +101,7 @@ data class SomeConfig(
                 nullableStrategy = nullableStrategy,
                 stringStrategy = stringStrategy,
                 collectionStrategy = collectionStrategy,
-                defaultValueStrategy = defaultValueStrategy
+                defaultValueStrategy = defaultValueStrategy,
             ),
             NullableResolver(nullableStrategy, random),
             ObjectResolver(),

--- a/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
@@ -32,6 +32,12 @@ class SomeConfigBuilder {
     var collectionStrategy: CollectionStrategy = CollectionStrategy()
 
     /**
+     * Strategy for handling data class constructor defaults.
+     * Defaults to [DefaultValueStrategy.UseDefault].
+     */
+    var defaultValueStrategy: DefaultValueStrategy = DefaultValueStrategy.UseDefault
+
+    /**
      * Seed for reproducible random generation.
      * If null, uses [kotlin.random.Random.Default].
      */
@@ -100,6 +106,7 @@ class SomeConfigBuilder {
         nullableStrategy = nullableStrategy,
         stringStrategy = stringStrategy,
         collectionStrategy = collectionStrategy,
+        defaultValueStrategy = defaultValueStrategy,
         seed = seed,
         typeFactories = _typeFactories.toMap(),
         propertyFactories = _propertyFactories.toMap()

--- a/src/main/kotlin/dev/appoutlet/some/core/FixtureContext.kt
+++ b/src/main/kotlin/dev/appoutlet/some/core/FixtureContext.kt
@@ -30,5 +30,5 @@ data class FixtureContext(
     val nullableStrategy: NullableStrategy,
     val stringStrategy: StringStrategy,
     val collectionStrategy: CollectionStrategy,
-    val defaultValueStrategy: DefaultValueStrategy
+    val defaultValueStrategy: DefaultValueStrategy,
 )

--- a/src/main/kotlin/dev/appoutlet/some/core/FixtureContext.kt
+++ b/src/main/kotlin/dev/appoutlet/some/core/FixtureContext.kt
@@ -1,6 +1,7 @@
 package dev.appoutlet.some.core
 
 import dev.appoutlet.some.config.CollectionStrategy
+import dev.appoutlet.some.config.DefaultValueStrategy
 import dev.appoutlet.some.config.NullableStrategy
 import dev.appoutlet.some.config.StringStrategy
 import kotlin.random.Random
@@ -21,11 +22,13 @@ import kotlin.reflect.KType
  * @property nullableStrategy Strategy currently used for nullable type handling.
  * @property stringStrategy Strategy currently used for generated string values.
  * @property collectionStrategy Strategy currently used for generated collection sizes.
+ * @property defaultValueStrategy Strategy currently used for handling constructor defaults.
  */
 data class FixtureContext(
     val random: Random,
     val resolutionStack: List<KType>,
     val nullableStrategy: NullableStrategy,
     val stringStrategy: StringStrategy,
-    val collectionStrategy: CollectionStrategy
+    val collectionStrategy: CollectionStrategy,
+    val defaultValueStrategy: DefaultValueStrategy
 )

--- a/src/main/kotlin/dev/appoutlet/some/resolver/CustomTypeFactoryResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/CustomTypeFactoryResolver.kt
@@ -1,6 +1,7 @@
 package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.CollectionStrategy
+import dev.appoutlet.some.config.DefaultValueStrategy
 import dev.appoutlet.some.config.NullableStrategy
 import dev.appoutlet.some.config.StringStrategy
 import dev.appoutlet.some.core.FixtureContext
@@ -25,13 +26,15 @@ import kotlin.reflect.KType
  * @param nullableStrategy Nullable handling strategy exposed to type factories through [FixtureContext].
  * @param stringStrategy String generation strategy exposed to type factories through [FixtureContext].
  * @param collectionStrategy Collection sizing strategy exposed to type factories through [FixtureContext].
+ * @param defaultValueStrategy Default value strategy exposed to type factories through [FixtureContext].
  */
 class CustomTypeFactoryResolver(
     private val typeFactories: Map<KClass<*>, FixtureContext.() -> Any?>,
     private val random: Random,
     private val nullableStrategy: NullableStrategy,
     private val stringStrategy: StringStrategy,
-    private val collectionStrategy: CollectionStrategy
+    private val collectionStrategy: CollectionStrategy,
+    private val defaultValueStrategy: DefaultValueStrategy
 ) : TypeResolver {
     /**
      * Returns whether [type] has a registered type factory.
@@ -68,7 +71,8 @@ class CustomTypeFactoryResolver(
             resolutionStack = chain.stack, // This returns an immutable snapshot
             nullableStrategy = nullableStrategy,
             stringStrategy = stringStrategy,
-            collectionStrategy = collectionStrategy
+            collectionStrategy = collectionStrategy,
+            defaultValueStrategy = defaultValueStrategy
         )
 
         return typeFactory.invoke(context)

--- a/src/main/kotlin/dev/appoutlet/some/resolver/CustomTypeFactoryResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/CustomTypeFactoryResolver.kt
@@ -34,7 +34,7 @@ class CustomTypeFactoryResolver(
     private val nullableStrategy: NullableStrategy,
     private val stringStrategy: StringStrategy,
     private val collectionStrategy: CollectionStrategy,
-    private val defaultValueStrategy: DefaultValueStrategy
+    private val defaultValueStrategy: DefaultValueStrategy,
 ) : TypeResolver {
     /**
      * Returns whether [type] has a registered type factory.
@@ -72,7 +72,7 @@ class CustomTypeFactoryResolver(
             nullableStrategy = nullableStrategy,
             stringStrategy = stringStrategy,
             collectionStrategy = collectionStrategy,
-            defaultValueStrategy = defaultValueStrategy
+            defaultValueStrategy = defaultValueStrategy,
         )
 
         return typeFactory.invoke(context)

--- a/src/main/kotlin/dev/appoutlet/some/resolver/DataClassResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/DataClassResolver.kt
@@ -1,6 +1,7 @@
 package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.CollectionStrategy
+import dev.appoutlet.some.config.DefaultValueStrategy
 import dev.appoutlet.some.config.NullableStrategy
 import dev.appoutlet.some.config.StringStrategy
 import dev.appoutlet.some.core.FixtureContext
@@ -34,6 +35,7 @@ import kotlin.reflect.full.primaryConstructor
  * @param nullableStrategy Nullable handling strategy exposed to property factories through [FixtureContext].
  * @param stringStrategy String generation strategy exposed to property factories through [FixtureContext].
  * @param collectionStrategy Collection sizing strategy exposed to property factories through [FixtureContext].
+ * @param defaultValueStrategy Strategy for handling constructor defaults.
  */
 class DataClassResolver(
     private val propertyFactories: Map<Pair<KClass<*>, String>, FixtureContext.() -> Any?> = emptyMap(),
@@ -41,6 +43,7 @@ class DataClassResolver(
     private val nullableStrategy: NullableStrategy = NullableStrategy.NullOnCircularReference,
     private val stringStrategy: StringStrategy = StringStrategy.Random(),
     private val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    private val defaultValueStrategy: DefaultValueStrategy = DefaultValueStrategy.UseDefault,
 ) : TypeResolver {
     /**
      * Returns whether [type] can be instantiated by this resolver.
@@ -99,15 +102,18 @@ class DataClassResolver(
             resolutionStack = chain.stack,
             nullableStrategy = nullableStrategy,
             stringStrategy = stringStrategy,
-            collectionStrategy = collectionStrategy
+            collectionStrategy = collectionStrategy,
+            defaultValueStrategy = defaultValueStrategy,
         )
 
         val args = constructor.parameters
             .mapNotNull { param ->
                 val propertyFactory = propertyFactories[kClass to param.name]
+                val shouldGenerate = !param.isOptional || defaultValueStrategy == DefaultValueStrategy.Generate
+
                 if (propertyFactory != null) {
                     param to propertyFactory(context)
-                } else if (!param.isOptional) {
+                } else if (shouldGenerate) {
                     val paramType = param.type
                     val resolvedType = typeArgMap[paramType.toString()] ?: paramType
                     param to chain.resolve(resolvedType)

--- a/src/test/kotlin/dev/appoutlet/some/integration/DefaultValueStrategyIntegrationTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/integration/DefaultValueStrategyIntegrationTest.kt
@@ -1,0 +1,69 @@
+package dev.appoutlet.some.integration
+
+import dev.appoutlet.some.config.DefaultValueStrategy
+import dev.appoutlet.some.some
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class DefaultValueStrategyIntegrationTest {
+
+    data class OptionalData(
+        val required: String,
+        val optional: String = "default value"
+    )
+
+    @Test
+    fun `should use default value when strategy is UseDefault`() {
+        val result: OptionalData = some {
+            defaultValueStrategy = DefaultValueStrategy.UseDefault
+        }
+
+        assertEquals("default value", result.optional)
+    }
+
+    @Test
+    fun `should use default value by default`() {
+        val result: OptionalData = some()
+
+        assertEquals("default value", result.optional)
+    }
+
+    @Test
+    fun `should generate value when strategy is Generate`() {
+        val result: OptionalData = some {
+            defaultValueStrategy = DefaultValueStrategy.Generate
+        }
+
+        assertNotEquals("default value", result.optional)
+    }
+
+    @Test
+    fun `property factory should take precedence over UseDefault`() {
+        val result: OptionalData = some {
+            defaultValueStrategy = DefaultValueStrategy.UseDefault
+            property(OptionalData::optional) { "custom value" }
+        }
+
+        assertEquals("custom value", result.optional)
+    }
+
+    @Test
+    fun `property factory should take precedence over Generate`() {
+        val result: OptionalData = some {
+            defaultValueStrategy = DefaultValueStrategy.Generate
+            property(OptionalData::optional) { "custom value" }
+        }
+
+        assertEquals("custom value", result.optional)
+    }
+
+    @Test
+    fun `non-optional parameters should still be resolved`() {
+        val result: OptionalData = some {
+            defaultValueStrategy = DefaultValueStrategy.Generate
+        }
+
+        assertNotEquals("", result.required)
+    }
+}


### PR DESCRIPTION
Implemented DefaultValueStrategy to control how data class constructor defaults are handled. The default behavior remains backward compatible (UseDefault), but users can now opt into generating values for all optional parameters using DefaultValueStrategy.Generate. Added tests and documentation.

Fixes #42

---
*PR created automatically by Jules for task [16197569111996853182](https://jules.google.com/task/16197569111996853182) started by @MessiasLima*