### PR TITLE
Implement StrategyProvider - Jules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,24 @@ class MyTypeResolverTest {
 - Use custom exceptions in `dev.appoutlet.some.exception` package
 - Exception classes extend `Exception` with descriptive messages
 
+### Strategy and Factory Registration
+Strategies and type factories are registered through [SomeConfigBuilder]:
+
+```kotlin
+someSetup {
+    // Register a custom strategy
+    strategy(MyCustomStrategy())
+
+    // Register a custom type factory (formerly register())
+    factory(MyType::class) {
+        MyType(name = "Custom")
+    }
+}
+```
+
 ### Resolver Registration Order (in SomeConfig)
 Order matters - first match wins:
-1. CustomTypeFactoryResolver (user overrides)
+1. CustomTypeFactoryResolver (user overrides via factory())
 2. NullableResolver
 3. ObjectResolver, EnumResolver, SealedClassResolver, ValueClassResolver
 4. Primitive resolvers (String, Int, Long, etc.)

--- a/src/main/kotlin/dev/appoutlet/some/Some.kt
+++ b/src/main/kotlin/dev/appoutlet/some/Some.kt
@@ -29,7 +29,7 @@ class Some(
      */
     @Suppress("MemberNameEqualsClassName")
     inline fun <reified T> some(): T {
-        val session = ResolverChain(resolvers, config.nullableStrategy)
+        val session = ResolverChain(resolvers, config)
         return session.resolve(typeOf<T>()) as T
     }
 
@@ -89,7 +89,7 @@ val defaultResolvers: List<TypeResolver> by lazy { defaultConfig.buildResolvers(
  * @return Generated value of type [T].
  */
 inline fun <reified T> some(): T {
-    val session = ResolverChain(defaultResolvers, defaultConfig.nullableStrategy)
+    val session = ResolverChain(defaultResolvers, defaultConfig)
     return session.resolve(typeOf<T>()) as T
 }
 

--- a/src/main/kotlin/dev/appoutlet/some/config/CollectionStrategy.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/CollectionStrategy.kt
@@ -6,7 +6,7 @@ private val defaultSizeRange = DEFAULT_SIZE_RANGE_START..DEFAULT_SIZE_RANGE_END
 
 data class CollectionStrategy(
     val sizeRange: IntRange = defaultSizeRange
-) {
+) : Strategy {
     init {
         require(sizeRange.first > -1) { "sizeRange.start must be positive" }
         require(sizeRange.last > sizeRange.first) { "sizeRange.end must be greater than or equal to sizeRange.start" }

--- a/src/main/kotlin/dev/appoutlet/some/config/NullableStrategy.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/NullableStrategy.kt
@@ -34,7 +34,7 @@ package dev.appoutlet.some.config
  * some { nullableStrategy = NullableStrategy.Random(probability = 0.0) }
  * ```
  */
-sealed interface NullableStrategy {
+sealed interface NullableStrategy : Strategy {
     /**
      * Returns `null` when a circular reference is detected for a nullable type.
      *

--- a/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
@@ -1,6 +1,7 @@
 package dev.appoutlet.some.config
 
 import dev.appoutlet.some.core.FixtureContext
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import dev.appoutlet.some.resolver.ArrayResolver
 import dev.appoutlet.some.resolver.BigDecimalResolver
@@ -38,17 +39,15 @@ import kotlin.reflect.KClass
 /**
  * Immutable configuration for customizing the behavior of [some][dev.appoutlet.some.some] fixture generation.
  *
- * Controls nullable handling, string generation, collection sizing, random seeding, type factories, and property
- * factories. Each generation call uses a [SomeConfig] to build an ordered resolver list, and that resolver order
- * defines which customization wins when multiple options could apply.
+ * Controls generation strategies, random seeding, type factories, and property factories. Each generation call uses
+ * a [SomeConfig] to build an ordered resolver list, and that resolver order defines which customization wins when
+ * multiple options could apply.
  *
  * Prefer [SomeConfigBuilder] through `some { ... }` or `someSetup { ... }` for user-facing configuration. Direct
  * construction is useful for tests or library integrations that need to assemble configuration values explicitly.
  * Use [toBuilder] to derive a mutable copy without mutating the original configuration.
  *
- * @param nullableStrategy Strategy for handling nullable type resolution.
- * @param stringStrategy Strategy for generating values handled by [StringResolver].
- * @param collectionStrategy Strategy for collection sizes handled by collection resolvers.
+ * @param strategies Map of strategies keyed by their [Strategy] implementation class.
  * @param seed Seed for reproducible random generation. When `null`, [Random.Default] is used.
  * @param typeFactories Custom type factories keyed by the exact class they override. These are resolved before all
  * built-in resolvers.
@@ -57,14 +56,23 @@ import kotlin.reflect.KClass
  * applied by [ClassResolver] while constructing model objects.
  */
 data class SomeConfig(
-    val nullableStrategy: NullableStrategy = NullableStrategy.NullOnCircularReference,
-    val stringStrategy: StringStrategy = StringStrategy.Random(),
-    val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    private val strategies: Map<KClass<out Strategy>, Strategy> = mapOf(
+        NullableStrategy::class to NullableStrategy.NullOnCircularReference,
+        StringStrategy::class to StringStrategy.Random(),
+        CollectionStrategy::class to CollectionStrategy(),
+    ),
     val defaultValueStrategy: DefaultValueStrategy = DefaultValueStrategy.UseDefault,
     val seed: Long? = null,
     val typeFactories: Map<KClass<*>, FixtureContext.() -> Any?> = emptyMap(),
     val propertyFactories: Map<Pair<KClass<*>, String>, FixtureContext.() -> Any?> = emptyMap(),
-) {
+) : StrategyProvider {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Strategy> get(key: KClass<T>): T {
+        return strategies[key] as? T
+            ?: throw IllegalArgumentException("Strategy ${key.simpleName} not registered")
+    }
+
     /**
      * Creates a [SomeConfigBuilder] pre-populated with this configuration's values.
      *
@@ -74,9 +82,7 @@ data class SomeConfig(
      * @return A [SomeConfigBuilder] containing this configuration's current state.
      */
     fun toBuilder(): SomeConfigBuilder = SomeConfigBuilder().apply {
-        nullableStrategy = this@SomeConfig.nullableStrategy
-        stringStrategy = this@SomeConfig.stringStrategy
-        collectionStrategy = this@SomeConfig.collectionStrategy
+        populateStrategies(this@SomeConfig.strategies)
         defaultValueStrategy = this@SomeConfig.defaultValueStrategy
         seed = this@SomeConfig.seed
         populateTypeFactories(this@SomeConfig.typeFactories)
@@ -98,17 +104,15 @@ data class SomeConfig(
             CustomTypeFactoryResolver(
                 typeFactories = typeFactories,
                 random = random,
-                nullableStrategy = nullableStrategy,
-                stringStrategy = stringStrategy,
-                collectionStrategy = collectionStrategy,
+                strategyProvider = this,
                 defaultValueStrategy = defaultValueStrategy,
             ),
-            NullableResolver(nullableStrategy, random),
+            NullableResolver(this, random),
             ObjectResolver(),
             EnumResolver(random),
             SealedClassResolver(random),
             ValueClassResolver(),
-            StringResolver(stringStrategy, random),
+            StringResolver(this, random),
             IntResolver(random),
             LongResolver(random),
             DoubleResolver(random),
@@ -127,16 +131,14 @@ data class SomeConfig(
             BigIntegerResolver(random),
             LocalDateResolver(random),
             LocalDateTimeResolver(random),
-            ListResolver(collectionStrategy, random),
-            SetResolver(collectionStrategy, random),
-            MapResolver(collectionStrategy, random),
-            ArrayResolver(collectionStrategy, random),
+            ListResolver(this, random),
+            SetResolver(this, random),
+            MapResolver(this, random),
+            ArrayResolver(this, random),
             ClassResolver(
                 propertyFactories = propertyFactories,
                 random = random,
-                nullableStrategy = nullableStrategy,
-                stringStrategy = stringStrategy,
-                collectionStrategy = collectionStrategy,
+                strategyProvider = this,
                 defaultValueStrategy = defaultValueStrategy,
             )
         )

--- a/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
@@ -18,24 +18,24 @@ class SomeConfigBuilder {
      * Defaults to [NullableStrategy.NullOnCircularReference].
      */
     var nullableStrategy: NullableStrategy
-        get() = _strategies[NullableStrategy::class] as NullableStrategy
-        set(value) { _strategies[NullableStrategy::class] = value }
+        get() = strategiesMap[NullableStrategy::class] as NullableStrategy
+        set(value) { strategiesMap[NullableStrategy::class] = value }
 
     /**
      * Strategy for generating string values.
      * Defaults to [StringStrategy.Random].
      */
     var stringStrategy: StringStrategy
-        get() = _strategies[StringStrategy::class] as StringStrategy
-        set(value) { _strategies[StringStrategy::class] = value }
+        get() = strategiesMap[StringStrategy::class] as StringStrategy
+        set(value) { strategiesMap[StringStrategy::class] = value }
 
     /**
      * Strategy for generating collection sizes.
      * Defaults to [CollectionStrategy] with a range of 1..5.
      */
     var collectionStrategy: CollectionStrategy
-        get() = _strategies[CollectionStrategy::class] as CollectionStrategy
-        set(value) { _strategies[CollectionStrategy::class] = value }
+        get() = strategiesMap[CollectionStrategy::class] as CollectionStrategy
+        set(value) { strategiesMap[CollectionStrategy::class] = value }
 
     /**
      * Strategy for handling data class constructor defaults.
@@ -50,7 +50,7 @@ class SomeConfigBuilder {
     var seed: Long? = null
 
     @PublishedApi
-    internal val _strategies: MutableMap<KClass<out Strategy>, Strategy> = mutableMapOf(
+    internal val strategiesMap: MutableMap<KClass<out Strategy>, Strategy> = mutableMapOf(
         NullableStrategy::class to NullableStrategy.NullOnCircularReference,
         StringStrategy::class to StringStrategy.Random(),
         CollectionStrategy::class to CollectionStrategy(),
@@ -65,7 +65,7 @@ class SomeConfigBuilder {
      * @param strategy The strategy instance to register.
      */
     inline fun <reified T : Strategy> strategy(strategy: T) {
-        _strategies[T::class] = strategy
+        strategiesMap[T::class] = strategy
     }
 
     /**
@@ -111,7 +111,7 @@ class SomeConfigBuilder {
      * @param strategies Map of strategy registrations to copy into this builder.
      */
     internal fun populateStrategies(strategies: Map<KClass<out Strategy>, Strategy>) {
-        _strategies.putAll(strategies)
+        strategiesMap.putAll(strategies)
     }
 
     /**
@@ -144,7 +144,7 @@ class SomeConfigBuilder {
      * @return A new [SomeConfig] instance with the configured values.
      */
     fun build(): SomeConfig = SomeConfig(
-        strategies = _strategies.toMap(),
+        strategies = strategiesMap.toMap(),
         defaultValueStrategy = defaultValueStrategy,
         seed = seed,
         typeFactories = _typeFactories.toMap(),

--- a/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
@@ -17,19 +17,25 @@ class SomeConfigBuilder {
      * Strategy for handling nullable type resolution.
      * Defaults to [NullableStrategy.NullOnCircularReference].
      */
-    var nullableStrategy: NullableStrategy = NullableStrategy.NullOnCircularReference
+    var nullableStrategy: NullableStrategy
+        get() = _strategies[NullableStrategy::class] as NullableStrategy
+        set(value) { _strategies[NullableStrategy::class] = value }
 
     /**
      * Strategy for generating string values.
      * Defaults to [StringStrategy.Random].
      */
-    var stringStrategy: StringStrategy = StringStrategy.Random()
+    var stringStrategy: StringStrategy
+        get() = _strategies[StringStrategy::class] as StringStrategy
+        set(value) { _strategies[StringStrategy::class] = value }
 
     /**
      * Strategy for generating collection sizes.
      * Defaults to [CollectionStrategy] with a range of 1..5.
      */
-    var collectionStrategy: CollectionStrategy = CollectionStrategy()
+    var collectionStrategy: CollectionStrategy
+        get() = _strategies[CollectionStrategy::class] as CollectionStrategy
+        set(value) { _strategies[CollectionStrategy::class] = value }
 
     /**
      * Strategy for handling data class constructor defaults.
@@ -43,8 +49,24 @@ class SomeConfigBuilder {
      */
     var seed: Long? = null
 
+    @PublishedApi
+    internal val _strategies: MutableMap<KClass<out Strategy>, Strategy> = mutableMapOf(
+        NullableStrategy::class to NullableStrategy.NullOnCircularReference,
+        StringStrategy::class to StringStrategy.Random(),
+        CollectionStrategy::class to CollectionStrategy(),
+    )
     private val _typeFactories: MutableMap<KClass<*>, FixtureContext.() -> Any?> = mutableMapOf()
     private val _propertyFactories: MutableMap<Pair<KClass<*>, String>, FixtureContext.() -> Any?> = mutableMapOf()
+
+    /**
+     * Registers a strategy instance.
+     *
+     * @param T The strategy type.
+     * @param strategy The strategy instance to register.
+     */
+    inline fun <reified T : Strategy> strategy(strategy: T) {
+        _strategies[T::class] = strategy
+    }
 
     /**
      * Registers a custom type factory function for type [T].
@@ -55,8 +77,16 @@ class SomeConfigBuilder {
      * @param kClass The [KClass] of the type to override.
      * @param typeFactory Lambda receiving a [FixtureContext] and returning a value of type [T].
      */
-    fun <T : Any> register(kClass: KClass<T>, typeFactory: FixtureContext.() -> T) {
+    fun <T : Any> factory(kClass: KClass<T>, typeFactory: FixtureContext.() -> T) {
         _typeFactories[kClass] = typeFactory
+    }
+
+    /**
+     * Deprecated: Use [factory] instead.
+     */
+    @Deprecated("Use factory() instead", ReplaceWith("factory(kClass, typeFactory)"))
+    fun <T : Any> register(kClass: KClass<T>, typeFactory: FixtureContext.() -> T) {
+        factory(kClass, typeFactory)
     }
 
     /**
@@ -71,6 +101,17 @@ class SomeConfigBuilder {
         val kClass = property.instanceParameter?.type?.classifier as? KClass<*>
             ?: error("Could not determine class for property ${property.name}")
         _propertyFactories[kClass to property.name] = factory
+    }
+
+    /**
+     * Populates the builder's strategy map with entries from an existing map.
+     *
+     * Used internally by [SomeConfig.toBuilder] to transfer strategy registrations.
+     *
+     * @param strategies Map of strategy registrations to copy into this builder.
+     */
+    internal fun populateStrategies(strategies: Map<KClass<out Strategy>, Strategy>) {
+        _strategies.putAll(strategies)
     }
 
     /**
@@ -103,9 +144,7 @@ class SomeConfigBuilder {
      * @return A new [SomeConfig] instance with the configured values.
      */
     fun build(): SomeConfig = SomeConfig(
-        nullableStrategy = nullableStrategy,
-        stringStrategy = stringStrategy,
-        collectionStrategy = collectionStrategy,
+        strategies = _strategies.toMap(),
         defaultValueStrategy = defaultValueStrategy,
         seed = seed,
         typeFactories = _typeFactories.toMap(),

--- a/src/main/kotlin/dev/appoutlet/some/config/Strategy.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/Strategy.kt
@@ -1,0 +1,6 @@
+package dev.appoutlet.some.config
+
+/**
+ * Marker interface for all generation strategies.
+ */
+interface Strategy

--- a/src/main/kotlin/dev/appoutlet/some/config/StringStrategy.kt
+++ b/src/main/kotlin/dev/appoutlet/some/config/StringStrategy.kt
@@ -16,7 +16,7 @@ package dev.appoutlet.some.config
  * val some = someSetup { stringStrategy = StringStrategy.Uuid }
  * ```
  */
-sealed interface StringStrategy {
+sealed interface StringStrategy : Strategy {
     /**
      * Generates random lowercase alphabetic strings.
      * @param length The length of the generated string (default 8)

--- a/src/main/kotlin/dev/appoutlet/some/core/FixtureContext.kt
+++ b/src/main/kotlin/dev/appoutlet/some/core/FixtureContext.kt
@@ -1,17 +1,14 @@
 package dev.appoutlet.some.core
 
-import dev.appoutlet.some.config.CollectionStrategy
 import dev.appoutlet.some.config.DefaultValueStrategy
-import dev.appoutlet.some.config.NullableStrategy
-import dev.appoutlet.some.config.StringStrategy
 import kotlin.random.Random
 import kotlin.reflect.KType
 
 /**
  * Runtime context provided as the receiver for custom factory functions.
  *
- * Both type factories registered with `register` and property factories registered with `property` receive this
- * context. It exposes the same random source and generation strategies used by the resolver chain so custom values
+ * Both type factories registered with `factory` and property factories registered with `property` receive this
+ * context. It exposes the same random source and strategy provider used by the resolver chain so custom values
  * can stay consistent with the active [dev.appoutlet.some.config.SomeConfig].
  *
  * The context is a snapshot for the current factory invocation. In particular, [resolutionStack] is immutable from the
@@ -19,16 +16,12 @@ import kotlin.reflect.KType
  *
  * @property random Random source for factory-generated values. This respects the configured seed when one is set.
  * @property resolutionStack Types currently being resolved, ordered from the outermost request to the current type.
- * @property nullableStrategy Strategy currently used for nullable type handling.
- * @property stringStrategy Strategy currently used for generated string values.
- * @property collectionStrategy Strategy currently used for generated collection sizes.
+ * @property strategyProvider Provider for accessing configured generation strategies.
  * @property defaultValueStrategy Strategy currently used for handling constructor defaults.
  */
 data class FixtureContext(
     val random: Random,
     val resolutionStack: List<KType>,
-    val nullableStrategy: NullableStrategy,
-    val stringStrategy: StringStrategy,
-    val collectionStrategy: CollectionStrategy,
+    val strategyProvider: StrategyProvider,
     val defaultValueStrategy: DefaultValueStrategy,
 )

--- a/src/main/kotlin/dev/appoutlet/some/core/ResolverChain.kt
+++ b/src/main/kotlin/dev/appoutlet/some/core/ResolverChain.kt
@@ -12,11 +12,11 @@ import kotlin.reflect.KType
  * Each call to `some()` creates a new instance of this session to ensure thread safety.
  *
  * @param resolvers Ordered resolver list. The first resolver that supports a type is used.
- * @param nullableStrategy Strategy used when a circular reference is detected for a nullable type.
+ * @param strategyProvider Provider used to retrieve the [NullableStrategy] when a circular reference is detected.
  */
 class ResolverChain(
     val resolvers: List<TypeResolver>,
-    private val nullableStrategy: NullableStrategy = NullableStrategy.NullOnCircularReference,
+    private val strategyProvider: StrategyProvider,
 ) {
     private val resolutionStack = mutableListOf<KType>()
 
@@ -73,7 +73,7 @@ class ResolverChain(
         return when {
             sameClassifierDetected.not() -> false
             type.isMarkedNullable -> true
-            resolutionStack.last().isMarkedNullable -> false
+            resolutionStack.lastOrNull()?.isMarkedNullable == true -> false
             else -> true
         }
     }
@@ -89,6 +89,7 @@ class ResolverChain(
      * @throws SomeCircularReferenceException when the circular reference cannot be resolved as `null`.
      */
     private fun handleCircularReference(type: KType): Nothing? {
+        val nullableStrategy = strategyProvider[NullableStrategy::class]
         val strategyAllowsNull = nullableStrategy is NullableStrategy.AlwaysNull ||
             nullableStrategy is NullableStrategy.NullOnCircularReference
 

--- a/src/main/kotlin/dev/appoutlet/some/core/StrategyProvider.kt
+++ b/src/main/kotlin/dev/appoutlet/some/core/StrategyProvider.kt
@@ -1,0 +1,16 @@
+package dev.appoutlet.some.core
+
+import dev.appoutlet.some.config.Strategy
+import kotlin.reflect.KClass
+
+/**
+ * Provides access to configured [Strategy] instances.
+ */
+interface StrategyProvider {
+    /**
+     * Retrieves the [Strategy] of type [key].
+     *
+     * @throws IllegalArgumentException if the strategy is not registered.
+     */
+    operator fun <T : Strategy> get(key: KClass<T>): T
+}

--- a/src/main/kotlin/dev/appoutlet/some/resolver/ArrayResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/ArrayResolver.kt
@@ -2,13 +2,14 @@ package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.CollectionStrategy
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import kotlin.random.Random
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 class ArrayResolver(
-    private val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    private val strategyProvider: StrategyProvider,
     val random: Random
 ) : TypeResolver {
     override fun canResolve(type: KType): Boolean {
@@ -17,6 +18,7 @@ class ArrayResolver(
     }
 
     override fun resolve(type: KType, chain: ResolverChain): Any {
+        val collectionStrategy = strategyProvider[CollectionStrategy::class]
         val elementType = type.arguments.firstOrNull()?.type
             ?: error("Star projection not supported in Array")
 

--- a/src/main/kotlin/dev/appoutlet/some/resolver/ClassResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/ClassResolver.kt
@@ -1,11 +1,9 @@
 package dev.appoutlet.some.resolver
 
-import dev.appoutlet.some.config.CollectionStrategy
 import dev.appoutlet.some.config.DefaultValueStrategy
-import dev.appoutlet.some.config.NullableStrategy
-import dev.appoutlet.some.config.StringStrategy
 import dev.appoutlet.some.core.FixtureContext
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import dev.appoutlet.some.exception.SomeCircularReferenceException
 import dev.appoutlet.some.exception.SomeInstantiationException
@@ -42,17 +40,13 @@ import kotlin.reflect.jvm.isAccessible
  *
  * @param propertyFactories Per-property factories keyed by owning class and constructor parameter name.
  * @param random Random source exposed to property factories through [FixtureContext].
- * @param nullableStrategy Nullable handling strategy exposed to property factories through [FixtureContext].
- * @param stringStrategy String generation strategy exposed to property factories through [FixtureContext].
- * @param collectionStrategy Collection sizing strategy exposed to property factories through [FixtureContext].
+ * @param strategyProvider Strategy provider exposed to property factories through [FixtureContext].
  * @param defaultValueStrategy Strategy for handling constructor defaults.
  */
 class ClassResolver(
     private val propertyFactories: Map<Pair<KClass<*>, String>, FixtureContext.() -> Any?> = emptyMap(),
     private val random: Random = Random.Default,
-    private val nullableStrategy: NullableStrategy = NullableStrategy.NullOnCircularReference,
-    private val stringStrategy: StringStrategy = StringStrategy.Random(),
-    private val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    private val strategyProvider: StrategyProvider,
     private val defaultValueStrategy: DefaultValueStrategy = DefaultValueStrategy.UseDefault,
 ) : TypeResolver {
     /**
@@ -173,9 +167,7 @@ class ClassResolver(
         val context = FixtureContext(
             random = random,
             resolutionStack = chain.stack,
-            nullableStrategy = nullableStrategy,
-            stringStrategy = stringStrategy,
-            collectionStrategy = collectionStrategy,
+            strategyProvider = strategyProvider,
             defaultValueStrategy = defaultValueStrategy,
         )
 

--- a/src/main/kotlin/dev/appoutlet/some/resolver/CustomTypeFactoryResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/CustomTypeFactoryResolver.kt
@@ -1,11 +1,9 @@
 package dev.appoutlet.some.resolver
 
-import dev.appoutlet.some.config.CollectionStrategy
 import dev.appoutlet.some.config.DefaultValueStrategy
-import dev.appoutlet.some.config.NullableStrategy
-import dev.appoutlet.some.config.StringStrategy
 import dev.appoutlet.some.core.FixtureContext
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import kotlin.random.Random
 import kotlin.reflect.KClass
@@ -23,17 +21,13 @@ import kotlin.reflect.KType
  *
  * @param typeFactories Map of classes to user-provided type factory functions.
  * @param random Random source exposed to type factories through [FixtureContext].
- * @param nullableStrategy Nullable handling strategy exposed to type factories through [FixtureContext].
- * @param stringStrategy String generation strategy exposed to type factories through [FixtureContext].
- * @param collectionStrategy Collection sizing strategy exposed to type factories through [FixtureContext].
+ * @param strategyProvider Strategy provider exposed to type factories through [FixtureContext].
  * @param defaultValueStrategy Default value strategy exposed to type factories through [FixtureContext].
  */
 class CustomTypeFactoryResolver(
     private val typeFactories: Map<KClass<*>, FixtureContext.() -> Any?>,
     private val random: Random,
-    private val nullableStrategy: NullableStrategy,
-    private val stringStrategy: StringStrategy,
-    private val collectionStrategy: CollectionStrategy,
+    private val strategyProvider: StrategyProvider,
     private val defaultValueStrategy: DefaultValueStrategy,
 ) : TypeResolver {
     /**
@@ -69,9 +63,7 @@ class CustomTypeFactoryResolver(
         val context = FixtureContext(
             random = random,
             resolutionStack = chain.stack, // This returns an immutable snapshot
-            nullableStrategy = nullableStrategy,
-            stringStrategy = stringStrategy,
-            collectionStrategy = collectionStrategy,
+            strategyProvider = strategyProvider,
             defaultValueStrategy = defaultValueStrategy,
         )
 

--- a/src/main/kotlin/dev/appoutlet/some/resolver/ListResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/ListResolver.kt
@@ -2,6 +2,7 @@ package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.CollectionStrategy
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import kotlin.random.Random
 import kotlin.reflect.KClass
@@ -11,7 +12,7 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
 
 class ListResolver(
-    private val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    private val strategyProvider: StrategyProvider,
     val random: Random
 ) : TypeResolver {
     override fun canResolve(type: KType): Boolean {
@@ -20,6 +21,7 @@ class ListResolver(
     }
 
     override fun resolve(type: KType, chain: ResolverChain): Any {
+        val collectionStrategy = strategyProvider[CollectionStrategy::class]
         val elementType = type.arguments.firstOrNull()?.type
             ?: error("Star projection not supported in List")
 

--- a/src/main/kotlin/dev/appoutlet/some/resolver/MapResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/MapResolver.kt
@@ -2,6 +2,7 @@ package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.CollectionStrategy
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import kotlin.random.Random
 import kotlin.reflect.KClass
@@ -11,7 +12,7 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
 
 class MapResolver(
-    private val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    private val strategyProvider: StrategyProvider,
     val random: Random
 ) : TypeResolver {
     override fun canResolve(type: KType): Boolean {
@@ -20,6 +21,7 @@ class MapResolver(
     }
 
     override fun resolve(type: KType, chain: ResolverChain): Any {
+        val collectionStrategy = strategyProvider[CollectionStrategy::class]
         val keyType = type.arguments.getOrNull(0)?.type
             ?: error("Star projection not supported in Map key")
         val valueType = type.arguments.getOrNull(1)?.type

--- a/src/main/kotlin/dev/appoutlet/some/resolver/NullableResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/NullableResolver.kt
@@ -2,6 +2,7 @@ package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.NullableStrategy
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import kotlin.random.Random
 import kotlin.reflect.KType
@@ -15,17 +16,17 @@ import kotlin.reflect.full.createType
  * - **NeverNull** – always resolves a non-null value.
  * - **Random** – returns `null` based on the strategy's probability.
  *
- * @param nullableStrategy Strategy used to decide whether nullable types should resolve to `null`.
+ * @param strategyProvider Provider used to retrieve the [NullableStrategy].
  * @param random Random source used by [NullableStrategy.Random].
  */
 class NullableResolver(
-    private val nullableStrategy: NullableStrategy = NullableStrategy.NullOnCircularReference,
+    private val strategyProvider: StrategyProvider,
     private val random: Random
 ) : TypeResolver {
     override fun canResolve(type: KType): Boolean = type.isMarkedNullable
 
     /**
-     * Resolves [type] according to [nullableStrategy].
+     * Resolves [type] according to the configured [NullableStrategy].
      *
      * Strategies that choose a concrete value resolve the non-null version of [type] through [chain].
      *
@@ -34,6 +35,7 @@ class NullableResolver(
      * @return `null` or a generated non-null value for [type].
      */
     override fun resolve(type: KType, chain: ResolverChain): Any? {
+        val nullableStrategy = strategyProvider[NullableStrategy::class]
         return when (nullableStrategy) {
             is NullableStrategy.NullOnCircularReference -> createNonNullInstance(type, chain)
             is NullableStrategy.AlwaysNull -> null

--- a/src/main/kotlin/dev/appoutlet/some/resolver/SetResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/SetResolver.kt
@@ -2,6 +2,7 @@ package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.CollectionStrategy
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import kotlin.random.Random
 import kotlin.reflect.KClass
@@ -11,7 +12,7 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.typeOf
 
 class SetResolver(
-    private val collectionStrategy: CollectionStrategy = CollectionStrategy(),
+    private val strategyProvider: StrategyProvider,
     val random: Random
 ) : TypeResolver {
     override fun canResolve(type: KType): Boolean {
@@ -20,6 +21,7 @@ class SetResolver(
     }
 
     override fun resolve(type: KType, chain: ResolverChain): Any {
+        val collectionStrategy = strategyProvider[CollectionStrategy::class]
         val elementType = type.arguments.firstOrNull()?.type
             ?: error("Star projection not supported in Set")
 

--- a/src/main/kotlin/dev/appoutlet/some/resolver/StringResolver.kt
+++ b/src/main/kotlin/dev/appoutlet/some/resolver/StringResolver.kt
@@ -2,6 +2,7 @@ package dev.appoutlet.some.resolver
 
 import dev.appoutlet.some.config.StringStrategy
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
 import kotlin.random.Random
 import kotlin.reflect.KType
@@ -11,12 +12,13 @@ import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalUuidApi::class)
 class StringResolver(
-    private val stringStrategy: StringStrategy = StringStrategy.Random(),
+    private val strategyProvider: StrategyProvider,
     val random: Random
 ) : TypeResolver {
     override fun canResolve(type: KType): Boolean = type == typeOf<String>()
 
     override fun resolve(type: KType, chain: ResolverChain): Any {
+        val stringStrategy = strategyProvider[StringStrategy::class]
         return when (stringStrategy) {
             is StringStrategy.Random -> generateRandomString(stringStrategy.length)
             is StringStrategy.Uuid -> Uuid.random().toString()

--- a/src/test/kotlin/dev/appoutlet/some/integration/CustomTypeFactoryIntegrationTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/integration/CustomTypeFactoryIntegrationTest.kt
@@ -9,7 +9,7 @@ class CustomTypeFactoryIntegrationTest {
     @Test
     fun `custom type factory overrides built-in resolver`() {
         val customSome = someSetup {
-            register(String::class) { "custom-value" }
+            factory(String::class) { "custom-value" }
         }
 
         data class Simple(val text: String)
@@ -23,7 +23,7 @@ class CustomTypeFactoryIntegrationTest {
 
         // Base config with custom type factory
         val baseSome = someSetup {
-            register(String::class) { "base-string" }
+            factory(String::class) { "base-string" }
         }
 
         val result1: Product = baseSome()
@@ -32,7 +32,7 @@ class CustomTypeFactoryIntegrationTest {
         // Aggregate with another custom type factory - should override in the aggregated config
         // This should NOT mutate the base config
         val result2: Product = baseSome {
-            register(String::class) { "overridden-string" }
+            factory(String::class) { "overridden-string" }
         }
         assertEquals("overridden-string", result2.name)
 

--- a/src/test/kotlin/dev/appoutlet/some/integration/PropertyFactoryIntegrationTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/integration/PropertyFactoryIntegrationTest.kt
@@ -61,7 +61,7 @@ class PropertyFactoryIntegrationTest {
     @Test
     fun `type factory should take precedence over property factory`() {
         val user = some<User> {
-            register(User::class) {
+            factory(User::class) {
                 User(
                     id = 123,
                     name = "TypeFactory",

--- a/src/test/kotlin/dev/appoutlet/some/resolver/ArrayResolverTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/resolver/ArrayResolverTest.kt
@@ -15,11 +15,13 @@ import kotlin.test.assertTrue
 class ArrayResolverTest {
     @Test
     fun `ArrayResolver generates array with correct size`() {
-        val config = SomeConfig(collectionStrategy = CollectionStrategy(3..5))
+        val config = SomeConfig().toBuilder().apply {
+            collectionStrategy = CollectionStrategy(3..5)
+        }.build()
         val resolvers = config.buildResolvers()
-        val resolver = ArrayResolver(CollectionStrategy(3..5), Random.Default)
+        val resolver = ArrayResolver(config, Random.Default)
 
-        val result = resolver.resolve(typeOf<Array<String>>(), ResolverChain(resolvers))
+        val result = resolver.resolve(typeOf<Array<String>>(), ResolverChain(resolvers, config))
         assertIs<Array<*>>(result)
         assertTrue(result.size in 3..5)
         assertTrue(result.all { it is String })
@@ -27,7 +29,7 @@ class ArrayResolverTest {
 
     @Test
     fun `ArrayResolver generates array with Int elements`() {
-        val resolver = ArrayResolver(CollectionStrategy(), Random.Default)
+        val resolver = ArrayResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<Array<Int>>(), defaultTestChain)
         assertIs<Array<*>>(result)
@@ -38,7 +40,7 @@ class ArrayResolverTest {
     fun `ArrayResolver generates array with Class elements`() {
         data class User(val name: String, val age: Int)
 
-        val resolver = ArrayResolver(CollectionStrategy(), Random.Default)
+        val resolver = ArrayResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<Array<User>>(), defaultTestChain)
         assertIs<Array<*>>(result)
@@ -47,14 +49,14 @@ class ArrayResolverTest {
 
     @Test
     fun `ArrayResolver canResolve detects Array types`() {
-        val resolver = ArrayResolver(CollectionStrategy(), Random.Default)
+        val resolver = ArrayResolver(SomeConfig(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<Array<String>>()))
         assertTrue(resolver.canResolve(typeOf<Array<Int>>()))
     }
 
     @Test
     fun `ArrayResolver rejects non-Array types`() {
-        val resolver = ArrayResolver(CollectionStrategy(), Random.Default)
+        val resolver = ArrayResolver(SomeConfig(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<String>()))
         assertFalse(resolver.canResolve(typeOf<Int>()))
         assertFalse(resolver.canResolve(typeOf<List<String>>()))
@@ -62,7 +64,7 @@ class ArrayResolverTest {
 
     @Test
     fun `ArrayResolver throws error on star projection`() {
-        val resolver = ArrayResolver(CollectionStrategy(), Random.Default)
+        val resolver = ArrayResolver(SomeConfig(), Random.Default)
 
         assertFailsWith<IllegalStateException> {
             resolver.resolve(typeOf<Array<*>>(), defaultTestChain)

--- a/src/test/kotlin/dev/appoutlet/some/resolver/ClassResolverTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/resolver/ClassResolverTest.kt
@@ -1,5 +1,6 @@
 package dev.appoutlet.some.resolver
 
+import dev.appoutlet.some.config.SomeConfig
 import dev.appoutlet.some.exception.SomeInstantiationException
 import dev.appoutlet.some.some
 import dev.appoutlet.some.test.defaultTestChain
@@ -42,7 +43,7 @@ sealed class TestSealed {
 }
 
 class ClassResolverTest {
-    private val resolver = ClassResolver(random = Random.Default)
+    private val resolver = ClassResolver(random = Random.Default, strategyProvider = SomeConfig())
 
     @Test
     fun `ClassResolver resolves data class with primary constructor`() {

--- a/src/test/kotlin/dev/appoutlet/some/resolver/ListResolverTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/resolver/ListResolverTest.kt
@@ -14,18 +14,20 @@ import kotlin.test.assertTrue
 class ListResolverTest {
     @Test
     fun `ListResolver generates list with correct size`() {
-        val config = SomeConfig(collectionStrategy = CollectionStrategy(3..5))
+        val config = SomeConfig().toBuilder().apply {
+            collectionStrategy = CollectionStrategy(3..5)
+        }.build()
         val resolvers = config.buildResolvers()
-        val resolver = ListResolver(CollectionStrategy(3..5), Random.Default)
+        val resolver = ListResolver(config, Random.Default)
 
-        val result = resolver.resolve(typeOf<List<String>>(), ResolverChain(resolvers))
+        val result = resolver.resolve(typeOf<List<String>>(), ResolverChain(resolvers, config))
         assertIs<List<*>>(result)
         assertTrue(result.size in 3..5)
     }
 
     @Test
     fun `ListResolver generates MutableList when requested`() {
-        val resolver = ListResolver(CollectionStrategy(), Random.Default)
+        val resolver = ListResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<MutableList<String>>(), defaultTestChain)
         assertIs<MutableList<*>>(result)
@@ -33,13 +35,13 @@ class ListResolverTest {
 
     @Test
     fun `ListResolver canResolve detects List types`() {
-        val resolver = ListResolver(CollectionStrategy(), Random.Default)
+        val resolver = ListResolver(SomeConfig(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<List<String>>()))
     }
 
     @Test
     fun `ListResolver rejects non-List types`() {
-        val resolver = ListResolver(CollectionStrategy(), Random.Default)
+        val resolver = ListResolver(SomeConfig(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<String>()))
         assertFalse(resolver.canResolve(typeOf<Int>()))
     }

--- a/src/test/kotlin/dev/appoutlet/some/resolver/MapResolverTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/resolver/MapResolverTest.kt
@@ -14,18 +14,20 @@ import kotlin.test.assertTrue
 class MapResolverTest {
     @Test
     fun `MapResolver generates map with correct size`() {
-        val config = SomeConfig(collectionStrategy = CollectionStrategy(2..4))
+        val config = SomeConfig().toBuilder().apply {
+            collectionStrategy = CollectionStrategy(2..4)
+        }.build()
         val resolvers = config.buildResolvers()
-        val resolver = MapResolver(CollectionStrategy(2..4), Random.Default)
+        val resolver = MapResolver(config, Random.Default)
 
-        val result = resolver.resolve(typeOf<Map<String, Int>>(), ResolverChain(resolvers))
+        val result = resolver.resolve(typeOf<Map<String, Int>>(), ResolverChain(resolvers, config))
         assertIs<Map<*, *>>(result)
         assertTrue(result.size in 2..4)
     }
 
     @Test
     fun `MapResolver generates MutableMap when requested`() {
-        val resolver = MapResolver(CollectionStrategy(), Random.Default)
+        val resolver = MapResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<MutableMap<String, Int>>(), defaultTestChain)
         assertIs<MutableMap<*, *>>(result)
@@ -33,13 +35,13 @@ class MapResolverTest {
 
     @Test
     fun `MapResolver canResolve detects Map types`() {
-        val resolver = MapResolver(CollectionStrategy(), Random.Default)
+        val resolver = MapResolver(SomeConfig(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<Map<String, Int>>()))
     }
 
     @Test
     fun `MapResolver rejects non-Map types`() {
-        val resolver = MapResolver(CollectionStrategy(), Random.Default)
+        val resolver = MapResolver(SomeConfig(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<String>()))
         assertFalse(resolver.canResolve(typeOf<Int>()))
     }

--- a/src/test/kotlin/dev/appoutlet/some/resolver/NullableResolverTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/resolver/NullableResolverTest.kt
@@ -16,7 +16,10 @@ import kotlin.test.assertTrue
 class NullableResolverTest {
     @Test
     fun `NullableResolver with AlwaysNull strategy returns null`() {
-        val resolver = NullableResolver(NullableStrategy.AlwaysNull, Random.Default)
+        val config = SomeConfig().toBuilder().apply {
+            nullableStrategy = NullableStrategy.AlwaysNull
+        }.build()
+        val resolver = NullableResolver(config, Random.Default)
 
         repeat(1000) {
             val result = resolver.resolve(typeOf<String?>(), defaultTestChain)
@@ -26,11 +29,13 @@ class NullableResolverTest {
 
     @Test
     fun `NullableResolver with NeverNull strategy generates non-null values`() {
-        val config = SomeConfig(nullableStrategy = NullableStrategy.NeverNull)
+        val config = SomeConfig().toBuilder().apply {
+            nullableStrategy = NullableStrategy.NeverNull
+        }.build()
         val resolvers = config.buildResolvers()
 
         repeat(1000) {
-            val result = ResolverChain(resolvers).resolve(typeOf<String?>())
+            val result = ResolverChain(resolvers, config).resolve(typeOf<String?>())
             assertNotNull(result)
             assertIs<String>(result)
         }
@@ -38,10 +43,12 @@ class NullableResolverTest {
 
     @Test
     fun `NullableResolver with Random strategy can return null or value`() {
-        val config = SomeConfig(nullableStrategy = NullableStrategy.Random())
+        val config = SomeConfig().toBuilder().apply {
+            nullableStrategy = NullableStrategy.Random()
+        }.build()
         val resolvers = config.buildResolvers()
 
-        val results = (1..100).map { ResolverChain(resolvers).resolve(typeOf<String?>()) }
+        val results = (1..100).map { ResolverChain(resolvers, config).resolve(typeOf<String?>()) }
         val hasNull = results.any { it == null }
         val hasValue = results.any { it != null }
         assertTrue(hasNull && hasValue)
@@ -49,11 +56,13 @@ class NullableResolverTest {
 
     @Test
     fun `NullableResolver with Random strategy and probability 0_0 always returns non-null`() {
-        val config = SomeConfig(nullableStrategy = NullableStrategy.Random(probability = 0.0))
+        val config = SomeConfig().toBuilder().apply {
+            nullableStrategy = NullableStrategy.Random(probability = 0.0)
+        }.build()
         val resolvers = config.buildResolvers()
 
         repeat(1000) {
-            val result = ResolverChain(resolvers).resolve(typeOf<String?>())
+            val result = ResolverChain(resolvers, config).resolve(typeOf<String?>())
             assertNotNull(result)
             assertIs<String>(result)
         }
@@ -61,24 +70,26 @@ class NullableResolverTest {
 
     @Test
     fun `NullableResolver with Random strategy and probability 1_0 always returns null`() {
-        val config = SomeConfig(nullableStrategy = NullableStrategy.Random(probability = 1.0))
+        val config = SomeConfig().toBuilder().apply {
+            nullableStrategy = NullableStrategy.Random(probability = 1.0)
+        }.build()
         val resolvers = config.buildResolvers()
 
         repeat(1000) {
-            val result = ResolverChain(resolvers).resolve(typeOf<String?>())
+            val result = ResolverChain(resolvers, config).resolve(typeOf<String?>())
             assertNull(result)
         }
     }
 
     @Test
     fun `NullableResolver canResolve detects nullable types`() {
-        val resolver = NullableResolver(NullableStrategy.Random(), Random.Default)
+        val resolver = NullableResolver(SomeConfig(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<String?>()))
     }
 
     @Test
     fun `NullableResolver rejects non-nullable types`() {
-        val resolver = NullableResolver(NullableStrategy.Random(), Random.Default)
+        val resolver = NullableResolver(SomeConfig(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<String>()))
     }
 }

--- a/src/test/kotlin/dev/appoutlet/some/resolver/SetResolverTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/resolver/SetResolverTest.kt
@@ -15,18 +15,20 @@ import kotlin.test.assertTrue
 class SetResolverTest {
     @Test
     fun `SetResolver generates set with correct size`() {
-        val config = SomeConfig(collectionStrategy = CollectionStrategy(3..5))
+        val config = SomeConfig().toBuilder().apply {
+            collectionStrategy = CollectionStrategy(3..5)
+        }.build()
         val resolvers = config.buildResolvers()
-        val resolver = SetResolver(CollectionStrategy(3..5), Random.Default)
+        val resolver = SetResolver(config, Random.Default)
 
-        val result = resolver.resolve(typeOf<Set<String>>(), ResolverChain(resolvers))
+        val result = resolver.resolve(typeOf<Set<String>>(), ResolverChain(resolvers, config))
         assertIs<Set<*>>(result)
         assertTrue(result.size in 3..5)
     }
 
     @Test
     fun `SetResolver generates set with elements of correct type`() {
-        val resolver = SetResolver(CollectionStrategy(), Random.Default)
+        val resolver = SetResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<Set<String>>(), defaultTestChain)
         assertIs<Set<*>>(result)
@@ -35,7 +37,7 @@ class SetResolverTest {
 
     @Test
     fun `SetResolver generates set with Int elements`() {
-        val resolver = SetResolver(CollectionStrategy(), Random.Default)
+        val resolver = SetResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<Set<Int>>(), defaultTestChain)
         assertIs<Set<*>>(result)
@@ -45,7 +47,7 @@ class SetResolverTest {
     @Test
     fun `SetResolver generates set of data class`() {
         data class DataClass(val a: Int, val b: String)
-        val resolver = SetResolver(CollectionStrategy(), Random.Default)
+        val resolver = SetResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<Set<DataClass>>(), defaultTestChain)
         assertIs<Set<DataClass>>(result)
@@ -53,7 +55,7 @@ class SetResolverTest {
 
     @Test
     fun `SetResolver generates MutableSet when requested`() {
-        val resolver = SetResolver(CollectionStrategy(), Random.Default)
+        val resolver = SetResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<MutableSet<String>>(), defaultTestChain)
         assertIs<MutableSet<*>>(result)
@@ -61,7 +63,7 @@ class SetResolverTest {
 
     @Test
     fun `SetResolver canResolve detects Set types`() {
-        val resolver = SetResolver(CollectionStrategy(), Random.Default)
+        val resolver = SetResolver(SomeConfig(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<Set<String>>()))
         assertTrue(resolver.canResolve(typeOf<Set<Int>>()))
         assertTrue(resolver.canResolve(typeOf<MutableSet<String>>()))
@@ -69,7 +71,7 @@ class SetResolverTest {
 
     @Test
     fun `SetResolver rejects non-Set types`() {
-        val resolver = SetResolver(CollectionStrategy(), Random.Default)
+        val resolver = SetResolver(SomeConfig(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<String>()))
         assertFalse(resolver.canResolve(typeOf<Int>()))
         assertFalse(resolver.canResolve(typeOf<List<String>>()))
@@ -77,7 +79,7 @@ class SetResolverTest {
 
     @Test
     fun `SetResolver throws error on star projection`() {
-        val resolver = SetResolver(CollectionStrategy(), Random.Default)
+        val resolver = SetResolver(SomeConfig(), Random.Default)
 
         assertFailsWith<IllegalStateException> {
             resolver.resolve(typeOf<Set<*>>(), defaultTestChain)

--- a/src/test/kotlin/dev/appoutlet/some/resolver/StringResolverTest.kt
+++ b/src/test/kotlin/dev/appoutlet/some/resolver/StringResolverTest.kt
@@ -17,9 +17,10 @@ import kotlin.uuid.Uuid
 
 class StringResolverTest {
     @Test
-    fun `StringResolver respects the default lenght`() {
-        val strategy = StringStrategy.Random()
-        val resolver = StringResolver(strategy, Random.Default)
+    fun `StringResolver respects the default length`() {
+        val config = SomeConfig()
+        val strategy = config.get(StringStrategy::class) as StringStrategy.Random
+        val resolver = StringResolver(config, Random.Default)
 
         val result = resolver.resolve(typeOf<String>(), defaultTestChain)
         assertIs<String>(result)
@@ -29,7 +30,10 @@ class StringResolverTest {
     @Test
     fun `StringResolver generates random string with custom length`() {
         val customLength = 16
-        val resolver = StringResolver(StringStrategy.Random(length = customLength), Random.Default)
+        val config = SomeConfig().toBuilder().apply {
+            stringStrategy = StringStrategy.Random(length = customLength)
+        }.build()
+        val resolver = StringResolver(config, Random.Default)
 
         val result = resolver.resolve(typeOf<String>(), defaultTestChain)
         assertIs<String>(result)
@@ -39,7 +43,10 @@ class StringResolverTest {
     @OptIn(ExperimentalUuidApi::class)
     @Test
     fun `StringResolver generates UUID when configured`() {
-        val resolver = StringResolver(StringStrategy.Uuid, Random.Default)
+        val config = SomeConfig().toBuilder().apply {
+            stringStrategy = StringStrategy.Uuid
+        }.build()
+        val resolver = StringResolver(config, Random.Default)
 
         val result = resolver.resolve(typeOf<String>(), defaultTestChain) as String
         val uuid = Uuid.parse(result)
@@ -49,7 +56,10 @@ class StringResolverTest {
 
     @Test
     fun `StringResolver generates readable strings`() {
-        val resolver = StringResolver(StringStrategy.Readable, Random.Default)
+        val config = SomeConfig().toBuilder().apply {
+            stringStrategy = StringStrategy.Readable
+        }.build()
+        val resolver = StringResolver(config, Random.Default)
 
         val result = resolver.resolve(typeOf<String>(), defaultTestChain)
         assertIs<String>(result)
@@ -58,22 +68,24 @@ class StringResolverTest {
 
     @Test
     fun `StringResolver canResolve detects String type`() {
-        val resolver = StringResolver(StringStrategy.Random(), Random.Default)
+        val resolver = StringResolver(SomeConfig(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<String>()))
     }
 
     @Test
     fun `StringResolver rejects non-String types`() {
-        val resolver = StringResolver(StringStrategy.Random(), Random.Default)
+        val resolver = StringResolver(SomeConfig(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<Int>()))
         assertFalse(resolver.canResolve(typeOf<Long>()))
     }
 
     @Test
     fun `StringStrategy Random with custom length integrates with SomeConfig`() {
-        val config = SomeConfig(stringStrategy = StringStrategy.Random(length = 20))
+        val config = SomeConfig().toBuilder().apply {
+            stringStrategy = StringStrategy.Random(length = 20)
+        }.build()
         val resolvers = config.buildResolvers()
-        val chain = ResolverChain(resolvers)
+        val chain = ResolverChain(resolvers, config)
 
         val result = chain.resolve(typeOf<String>())
         assertIs<String>(result)

--- a/src/test/kotlin/dev/appoutlet/some/test/TestHelpers.kt
+++ b/src/test/kotlin/dev/appoutlet/some/test/TestHelpers.kt
@@ -8,6 +8,7 @@ import dev.appoutlet.some.core.ResolverChain
  * Creates a chain with default configuration.
  */
 val defaultTestChain: ResolverChain by lazy {
-    val resolvers = SomeConfig().buildResolvers()
-    ResolverChain(resolvers)
+    val config = SomeConfig()
+    val resolvers = config.buildResolvers()
+    ResolverChain(resolvers, config)
 }


### PR DESCRIPTION
This change decouples strategy definitions from SomeConfig and the resolver chain by introducing a StrategyProvider. Users can now register custom strategies using `strategy(MyStrategy())` and resolvers retrieve them via `strategyProvider[MyStrategy::class]`. This removes the maintenance bottleneck where every new strategy required manual wiring in multiple files. Additionally, `register()` was renamed to `factory()` to better differentiate it from strategy registration.

Fixes #35

---
*PR created automatically by Jules for task [13573005225355871000](https://jules.google.com/task/13573005225355871000) started by @MessiasLima*