### PR TITLE
Add FloatStrategy to control generated Float value range

### DIFF
--- a/core/src/main/kotlin/dev/appoutlet/some/config/FloatStrategy.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/FloatStrategy.kt
@@ -1,0 +1,28 @@
+package dev.appoutlet.some.config
+
+/**
+ * Strategy for generating float values.
+ *
+ * @property range The range within which float values will be generated (default 0.0f..1.0f).
+ */
+data class FloatStrategy(
+    val range: ClosedFloatingPointRange<Float> = 0.0f..1.0f
+) : Strategy {
+    override val key = FloatStrategy::class
+
+    init {
+        require(range.start <= range.endInclusive) { "range.start must be less than or equal to range.endInclusive" }
+    }
+
+    /**
+     * Convenience constructor for a fixed float value.
+     */
+    constructor(fixed: Float) : this(fixed..fixed)
+
+    companion object {
+        /**
+         * The default float strategy.
+         */
+        val default: FloatStrategy get() = FloatStrategy()
+    }
+}

--- a/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
@@ -55,7 +55,7 @@ import kotlin.reflect.KClass
  * @param propertyFactories Custom property factories keyed by class and property name.
  */
 data class SomeConfig(
-    val strategies: Map<KClass<out Strategy>, Strategy> = emptyMap(),
+    val strategies: Map<KClass<out Strategy>, Strategy> = defaultStrategies(),
     val seed: Long? = null,
     val typeFactories: Map<KClass<*>, FixtureContext.() -> Any?> = emptyMap(),
     val propertyFactories: Map<Pair<KClass<*>, String>, FixtureContext.() -> Any?> = emptyMap(),
@@ -116,7 +116,7 @@ data class SomeConfig(
             IntResolver(random),
             LongResolver(random),
             DoubleResolver(random),
-            FloatResolver(random),
+            FloatResolver(strategyProvider, random),
             BooleanResolver(random),
             CharResolver(random),
             ByteResolver(random),
@@ -194,4 +194,17 @@ data class SomeConfig(
      * @return [Random] seeded with [seed] if set, or [Random.Default] otherwise.
      */
     internal fun buildRandom(): Random = seed?.let { Random(it) } ?: Random.Default
+
+    companion object {
+        /**
+         * Returns the default strategies for fixture generation.
+         */
+        fun defaultStrategies(): Map<KClass<out Strategy>, Strategy> = mapOf(
+            NullableStrategy::class to NullableStrategy.default,
+            StringStrategy::class to StringStrategy.default,
+            CollectionStrategy::class to CollectionStrategy.default,
+            FloatStrategy::class to FloatStrategy.default,
+            DefaultValueStrategy::class to DefaultValueStrategy.default,
+        )
+    }
 }

--- a/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
@@ -21,6 +21,7 @@ import kotlin.reflect.full.instanceParameter
  *     strategy(NullableStrategy.NeverNull)
  *     strategy(StringStrategy.Uuid)
  *     strategy(CollectionStrategy(5..10))
+ *     strategy(FloatStrategy(0.0f..100.0f))
  * }
  * ```
  *

--- a/core/src/main/kotlin/dev/appoutlet/some/config/Strategy.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/Strategy.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KClass
  * Marker interface for strategy objects that configure fixture generation behavior.
  *
  * All built-in strategies ([NullableStrategy], [StringStrategy], [CollectionStrategy],
- * and [DefaultValueStrategy]) implement this interface. Custom strategies can also be
+ * [FloatStrategy], and [DefaultValueStrategy]) implement this interface. Custom strategies can also be
  * created by implementing [Strategy] and registering them via [SomeConfigBuilder.strategy].
  *
  * The [key] property determines the registration bucket for the strategy. For sealed interface

--- a/core/src/main/kotlin/dev/appoutlet/some/resolver/FloatResolver.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/resolver/FloatResolver.kt
@@ -1,15 +1,32 @@
 package dev.appoutlet.some.resolver
 
+import dev.appoutlet.some.config.FloatStrategy
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
 import dev.appoutlet.some.core.TypeResolver
+import dev.appoutlet.some.core.get
 import kotlin.random.Random
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class FloatResolver(val random: Random) : TypeResolver {
+/**
+ * Resolves [Float] types using the active [FloatStrategy].
+ *
+ * @param strategyProvider Provider of all configured generation strategies.
+ * @param random Random source used for generating float values.
+ */
+class FloatResolver(
+    strategyProvider: StrategyProvider,
+    private val random: Random
+) : TypeResolver {
+    private val floatStrategy = strategyProvider.get<FloatStrategy>() ?: FloatStrategy.default
+
     override fun canResolve(type: KType): Boolean = type == typeOf<Float>()
 
     override fun resolve(type: KType, chain: ResolverChain): Any {
-        return random.nextFloat()
+        val range = floatStrategy.range
+        if (range.start == range.endInclusive) return range.start
+
+        return random.nextDouble(range.start.toDouble(), range.endInclusive.toDouble()).toFloat()
     }
 }

--- a/core/src/test/kotlin/dev/appoutlet/some/config/FloatStrategyTest.kt
+++ b/core/src/test/kotlin/dev/appoutlet/some/config/FloatStrategyTest.kt
@@ -1,0 +1,32 @@
+package dev.appoutlet.some.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FloatStrategyTest {
+    @Test
+    fun `default strategy uses range 0 to 1`() {
+        val strategy = FloatStrategy.default
+        assertEquals(0.0f..1.0f, strategy.range)
+    }
+
+    @Test
+    fun `secondary constructor pins value`() {
+        val strategy = FloatStrategy(5.0f)
+        assertEquals(5.0f..5.0f, strategy.range)
+    }
+
+    @Test
+    fun `validation rejects inverted range`() {
+        assertFailsWith<IllegalArgumentException> {
+            FloatStrategy(5.0f..2.0f)
+        }
+    }
+
+    @Test
+    fun `zero-width range is allowed`() {
+        val strategy = FloatStrategy(2.0f..2.0f)
+        assertEquals(2.0f..2.0f, strategy.range)
+    }
+}

--- a/core/src/test/kotlin/dev/appoutlet/some/resolver/FloatResolverTest.kt
+++ b/core/src/test/kotlin/dev/appoutlet/some/resolver/FloatResolverTest.kt
@@ -1,5 +1,7 @@
 package dev.appoutlet.some.resolver
 
+import dev.appoutlet.some.config.FloatStrategy
+import dev.appoutlet.some.config.SomeConfig
 import dev.appoutlet.some.test.defaultTestChain
 import kotlin.random.Random
 import kotlin.reflect.typeOf
@@ -7,35 +9,58 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 class FloatResolverTest {
     @Test
     fun `FloatResolver generates float values`() {
-        val resolver = FloatResolver(Random.Default)
+        val resolver = FloatResolver(SomeConfig(), Random.Default)
 
         val result = resolver.resolve(typeOf<Float>(), defaultTestChain)
         assertIs<Float>(result)
     }
 
     @Test
-    fun `FloatResolver generates values between 0 and 1`() {
-        val resolver = FloatResolver(Random.Default)
+    fun `FloatResolver generates values between 0 and 1 by default`() {
+        val resolver = FloatResolver(SomeConfig(), Random.Default)
 
         repeat(100) {
             val result = resolver.resolve(typeOf<Float>(), defaultTestChain) as Float
-            assertTrue(result in 0.0f..<1.0f, "Expected value between 0.0 and 1.0, got $result")
+            assertTrue(result in 0.0f..1.0f, "Expected value between 0.0 and 1.0, got $result")
+        }
+    }
+
+    @Test
+    fun `FloatResolver respects FloatStrategy range`() {
+        val config = SomeConfig(strategies = mapOf(FloatStrategy::class to FloatStrategy(10.0f..20.0f)))
+        val resolver = FloatResolver(config, Random.Default)
+
+        repeat(100) {
+            val result = resolver.resolve(typeOf<Float>(), defaultTestChain) as Float
+            assertTrue(result in 10.0f..20.0f, "Expected value between 10.0 and 20.0, got $result")
+        }
+    }
+
+    @Test
+    fun `FloatResolver handles zero-width range`() {
+        val config = SomeConfig(strategies = mapOf(FloatStrategy::class to FloatStrategy(5.0f)))
+        val resolver = FloatResolver(config, Random.Default)
+
+        repeat(10) {
+            val result = resolver.resolve(typeOf<Float>(), defaultTestChain) as Float
+            assertEquals(5.0f, result)
         }
     }
 
     @Test
     fun `FloatResolver canResolve detects Float type`() {
-        val resolver = FloatResolver(Random.Default)
+        val resolver = FloatResolver(SomeConfig(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<Float>()))
     }
 
     @Test
     fun `FloatResolver rejects non-Float types`() {
-        val resolver = FloatResolver(Random.Default)
+        val resolver = FloatResolver(SomeConfig(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<String>()))
         assertFalse(resolver.canResolve(typeOf<Int>()))
         assertFalse(resolver.canResolve(typeOf<Double>()))


### PR DESCRIPTION
This PR introduces `FloatStrategy`, enabling users to constrain the range of randomly generated `Float` values during fixture generation. 

Key changes:
- `FloatStrategy` data class added to `dev.appoutlet.some.config` with support for ranges and fixed values.
- `FloatResolver` now respects the configured `FloatStrategy`, falling back to a default range of `0.0f..1.0f` to maintain backward compatibility.
- `SomeConfig` updated to include `FloatStrategy` in its default strategies map and properly wire it to `FloatResolver`.
- Documentation updated to include `FloatStrategy` in the list of built-in strategies.
- Unit tests added to verify strategy validation, constructors, and resolver behavior.

Fixes #69

---
*PR created automatically by Jules for task [9804220812499711518](https://jules.google.com/task/9804220812499711518) started by @MessiasLima*