### PR TITLE
feat: float strategy

### DIFF
--- a/core/src/main/kotlin/dev/appoutlet/some/config/FloatStrategy.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/FloatStrategy.kt
@@ -1,0 +1,22 @@
+package dev.appoutlet.some.config
+
+data class FloatStrategy(
+    val range: ClosedFloatingPointRange<Float> = 0.0f..1.0f
+) : Strategy {
+    override val key = FloatStrategy::class
+
+    constructor(fixed: Float) : this(fixed..fixed)
+
+    init {
+        require(range.start <= range.endInclusive) {
+            "range.start must be less than or equal to range.endInclusive"
+        }
+    }
+
+    companion object {
+        /**
+         * The default float strategy.
+         */
+        val default: FloatStrategy get() = FloatStrategy()
+    }
+}

--- a/core/src/main/kotlin/dev/appoutlet/some/config/FloatStrategy.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/FloatStrategy.kt
@@ -17,6 +17,6 @@ data class FloatStrategy(
         /**
          * The default float strategy.
          */
-        val default: FloatStrategy get() = FloatStrategy()
+        val default = FloatStrategy()
     }
 }

--- a/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfig.kt
@@ -116,7 +116,7 @@ data class SomeConfig(
             IntResolver(random),
             LongResolver(random),
             DoubleResolver(random),
-            FloatResolver(random),
+            FloatResolver(strategyProvider, random),
             BooleanResolver(random),
             CharResolver(random),
             ByteResolver(random),

--- a/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/SomeConfigBuilder.kt
@@ -21,6 +21,7 @@ import kotlin.reflect.full.instanceParameter
  *     strategy(NullableStrategy.NeverNull)
  *     strategy(StringStrategy.Uuid)
  *     strategy(CollectionStrategy(5..10))
+ *     strategy(FloatStrategy(0.0f..10.0f))
  * }
  * ```
  *

--- a/core/src/main/kotlin/dev/appoutlet/some/config/Strategy.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/config/Strategy.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KClass
  * Marker interface for strategy objects that configure fixture generation behavior.
  *
  * All built-in strategies ([NullableStrategy], [StringStrategy], [CollectionStrategy],
- * and [DefaultValueStrategy]) implement this interface. Custom strategies can also be
+ * [FloatStrategy], and [DefaultValueStrategy]) implement this interface. Custom strategies can also be
  * created by implementing [Strategy] and registering them via [SomeConfigBuilder.strategy].
  *
  * The [key] property determines the registration bucket for the strategy. For sealed interface

--- a/core/src/main/kotlin/dev/appoutlet/some/resolver/FloatResolver.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/resolver/FloatResolver.kt
@@ -1,15 +1,28 @@
 package dev.appoutlet.some.resolver
 
+import dev.appoutlet.some.config.FloatStrategy
 import dev.appoutlet.some.core.Resolver
 import dev.appoutlet.some.core.ResolverChain
+import dev.appoutlet.some.core.StrategyProvider
+import dev.appoutlet.some.core.get
 import kotlin.random.Random
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class FloatResolver(val random: Random) : Resolver {
+class FloatResolver(
+    strategyProvider: StrategyProvider,
+    private val random: Random
+) : Resolver {
+    private val floatStrategy = strategyProvider.get<FloatStrategy>() ?: FloatStrategy.default
+
     override fun canResolve(type: KType): Boolean = type == typeOf<Float>()
 
     override fun resolve(type: KType, chain: ResolverChain): Any {
-        return random.nextFloat()
+        val range = floatStrategy.range
+        return if (range.start == range.endInclusive) {
+            range.start
+        } else {
+            range.start + random.nextFloat() * (range.endInclusive - range.start)
+        }
     }
 }

--- a/core/src/main/kotlin/dev/appoutlet/some/resolver/FloatResolver.kt
+++ b/core/src/main/kotlin/dev/appoutlet/some/resolver/FloatResolver.kt
@@ -22,7 +22,10 @@ class FloatResolver(
         return if (range.start == range.endInclusive) {
             range.start
         } else {
-            range.start + random.nextFloat() * (range.endInclusive - range.start)
+            random.nextDouble(
+                from = range.start.toDouble(),
+                until = range.endInclusive.toDouble(),
+            ).toFloat()
         }
     }
 }

--- a/core/src/test/kotlin/dev/appoutlet/some/config/FloatStrategyTest.kt
+++ b/core/src/test/kotlin/dev/appoutlet/some/config/FloatStrategyTest.kt
@@ -1,0 +1,67 @@
+package dev.appoutlet.some.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+class FloatStrategyTest {
+    @Test
+    fun `FloatStrategy has default range 0_0 to 1_0`() {
+        val strategy = FloatStrategy()
+        assertEquals(0.0f, strategy.range.start)
+        assertEquals(1.0f, strategy.range.endInclusive)
+    }
+
+    @Test
+    fun `FloatStrategy default companion is no-arg instance`() {
+        val strategy = FloatStrategy.default
+        assertEquals(0.0f, strategy.range.start)
+        assertEquals(1.0f, strategy.range.endInclusive)
+    }
+
+    @Test
+    fun `FloatStrategy accepts valid range`() {
+        val strategy = FloatStrategy(1.0f..5.0f)
+        assertEquals(1.0f, strategy.range.start)
+        assertEquals(5.0f, strategy.range.endInclusive)
+    }
+
+    @Test
+    fun `FloatStrategy accepts zero-width range`() {
+        val strategy = FloatStrategy(3.0f..3.0f)
+        assertEquals(3.0f, strategy.range.start)
+        assertEquals(3.0f, strategy.range.endInclusive)
+    }
+
+    @Test
+    fun `FloatStrategy accepts negative range`() {
+        val strategy = FloatStrategy(-5.0f..-1.0f)
+        assertEquals(-5.0f, strategy.range.start)
+        assertEquals(-1.0f, strategy.range.endInclusive)
+    }
+
+    @Test
+    fun `FloatStrategy rejects inverted range`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            FloatStrategy(5.0f..2.0f)
+        }
+        assertEquals(
+            "range.start must be less than or equal to range.endInclusive",
+            exception.message
+        )
+    }
+
+    @Test
+    fun `FloatStrategy fixed constructor is equivalent to zero-width range`() {
+        val fixed = FloatStrategy(3.0f)
+        val range = FloatStrategy(3.0f..3.0f)
+        assertEquals(range.range.start, fixed.range.start)
+        assertEquals(range.range.endInclusive, fixed.range.endInclusive)
+    }
+
+    @Test
+    fun `FloatStrategy key is its own class`() {
+        assertSame(FloatStrategy::class, FloatStrategy().key)
+    }
+}

--- a/core/src/test/kotlin/dev/appoutlet/some/resolver/FloatResolverTest.kt
+++ b/core/src/test/kotlin/dev/appoutlet/some/resolver/FloatResolverTest.kt
@@ -1,9 +1,15 @@
 package dev.appoutlet.some.resolver
 
+import dev.appoutlet.some.config.DefaultStrategyProvider
+import dev.appoutlet.some.config.FloatStrategy
+import dev.appoutlet.some.config.NullableStrategy
+import dev.appoutlet.some.config.buildSomeConfig
+import dev.appoutlet.some.core.ResolverChain
 import dev.appoutlet.some.test.defaultTestChain
 import kotlin.random.Random
 import kotlin.reflect.typeOf
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -11,15 +17,15 @@ import kotlin.test.assertTrue
 class FloatResolverTest {
     @Test
     fun `FloatResolver generates float values`() {
-        val resolver = FloatResolver(Random.Default)
+        val resolver = FloatResolver(DefaultStrategyProvider(), Random.Default)
 
         val result = resolver.resolve(typeOf<Float>(), defaultTestChain)
         assertIs<Float>(result)
     }
 
     @Test
-    fun `FloatResolver generates values between 0 and 1`() {
-        val resolver = FloatResolver(Random.Default)
+    fun `FloatResolver generates values between 0 and 1 by default`() {
+        val resolver = FloatResolver(DefaultStrategyProvider(), Random.Default)
 
         repeat(100) {
             val result = resolver.resolve(typeOf<Float>(), defaultTestChain) as Float
@@ -28,16 +34,69 @@ class FloatResolverTest {
     }
 
     @Test
+    fun `FloatResolver honors a custom range`() {
+        val resolver = FloatResolver(
+            DefaultStrategyProvider(mapOf(FloatStrategy::class to FloatStrategy(0.0f..10.0f))),
+            Random.Default
+        )
+
+        repeat(100) {
+            val result = resolver.resolve(typeOf<Float>(), defaultTestChain) as Float
+            assertTrue(result in 0.0f..<10.0f, "Expected value between 0.0 and 10.0, got $result")
+        }
+    }
+
+    @Test
+    fun `FloatResolver honors a negative range`() {
+        val resolver = FloatResolver(
+            DefaultStrategyProvider(mapOf(FloatStrategy::class to FloatStrategy(-5.0f..-1.0f))),
+            Random.Default
+        )
+
+        repeat(100) {
+            val result = resolver.resolve(typeOf<Float>(), defaultTestChain) as Float
+            assertTrue(result in -5.0f..<-1.0f, "Expected value between -5.0 and -1.0, got $result")
+        }
+    }
+
+    @Test
+    fun `FloatResolver always returns fixed value for pinned strategy`() {
+        val resolver = FloatResolver(
+            DefaultStrategyProvider(mapOf(FloatStrategy::class to FloatStrategy(5.0f))),
+            Random.Default
+        )
+
+        repeat(50) {
+            val result = resolver.resolve(typeOf<Float>(), defaultTestChain) as Float
+            assertEquals(5.0f, result)
+        }
+    }
+
+    @Test
     fun `FloatResolver canResolve detects Float type`() {
-        val resolver = FloatResolver(Random.Default)
+        val resolver = FloatResolver(DefaultStrategyProvider(), Random.Default)
         assertTrue(resolver.canResolve(typeOf<Float>()))
     }
 
     @Test
     fun `FloatResolver rejects non-Float types`() {
-        val resolver = FloatResolver(Random.Default)
+        val resolver = FloatResolver(DefaultStrategyProvider(), Random.Default)
         assertFalse(resolver.canResolve(typeOf<String>()))
         assertFalse(resolver.canResolve(typeOf<Int>()))
         assertFalse(resolver.canResolve(typeOf<Double>()))
+    }
+
+    @Test
+    fun `FloatStrategy integrates with SomeConfig`() {
+        val config = buildSomeConfig {
+            strategy(FloatStrategy(0.0f..10.0f))
+        }
+        val resolvers = config.buildResolvers()
+        val chain = ResolverChain(resolvers, config[NullableStrategy::class])
+
+        repeat(50) {
+            val result = chain.resolve(typeOf<Float>()) as Float
+            assertTrue(result in 0.0f..<10.0f, "Expected value between 0.0 and 10.0, got $result")
+        }
     }
 }

--- a/docs/configuration/float-strategy.md
+++ b/docs/configuration/float-strategy.md
@@ -1,0 +1,63 @@
+# Float Strategy
+
+Controls the range of `Float` values generated during fixture generation.
+
+## Configuration
+
+The `FloatStrategy` takes a single `range` parameter — a `ClosedFloatingPointRange<Float>` specifying the inclusive minimum and inclusive maximum of generated `Float` values. The end of the range is treated as exclusive during generation, matching `random.nextDouble(from, until)` semantics.
+
+```kotlin
+// Default: 0.0 to 1.0 (exclusive end)
+some { strategy(FloatStrategy()) }
+
+// Positive range
+some { strategy(FloatStrategy(0.0f..10.0f)) }
+
+// Negative range
+some { strategy(FloatStrategy(-5.0f..-1.0f)) }
+
+// Range that spans zero
+some { strategy(FloatStrategy(-1.0f..1.0f)) }
+```
+
+## Pinning a fixed value
+
+A secondary constructor `FloatStrategy(fixed: Float)` is provided as a convenience for pinning generation to a single value. It is equivalent to `FloatStrategy(fixed..fixed)`.
+
+```kotlin
+// Pin to a single value
+some { strategy(FloatStrategy(5.0f)) }
+
+// Equivalent zero-width range
+some { strategy(FloatStrategy(5.0f..5.0f)) }
+```
+
+Zero-width ranges (`start == endInclusive`) are always honored — the resolver returns the fixed value directly without invoking the random source.
+
+## Default
+
+| Property | Default value |
+|----------|---------------|
+| `range` | `0.0f..1.0f` |
+
+The default range preserves the behavior of `random.nextFloat()` (`[0.0, 1.0)`), so existing users see no change.
+
+## Affected types
+
+The float strategy applies to the `Float` primitive type:
+
+- `Float`
+
+## Validation
+
+The `FloatStrategy` constructor enforces one constraint on the `range` parameter via a `require()` check. It throws `IllegalArgumentException` on failure.
+
+### Start must be less than or equal to end
+
+`range.start` must be `<=` `range.endInclusive`. Inverted ranges are rejected; equal bounds (zero-width ranges) are allowed.
+
+```kotlin
+FloatStrategy(0.0f..1.0f)  // OK
+FloatStrategy(5.0f..2.0f)  // IllegalArgumentException: range.start must be less than or equal to range.endInclusive
+FloatStrategy(3.0f..3.0f)  // OK — zero-width range, always returns 3.0f
+```

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -71,6 +71,7 @@ val stillNeverNull: Person = baseSome()
 | `NullableStrategy` | `NullableStrategy.NullOnCircularReference` | Emits `null` for nullable circular references | [NullableStrategy](nullable-strategy.md) |
 | `StringStrategy` | `StringStrategy.Random()` | Random lowercase alphabetic strings | [StringStrategy](string-strategy.md) |
 | `CollectionStrategy` | `CollectionStrategy()` | Collections with 1 to 5 elements | [CollectionStrategy](collection-strategy.md) |
+| `FloatStrategy` | `FloatStrategy()` | Floats in the range `0.0f..1.0f` | [FloatStrategy](float-strategy.md) |
 | `DefaultValueStrategy` | `DefaultValueStrategy.UseDefault` | Uses Kotlin defaults for optional parameters | [DefaultValueStrategy](default-value-strategy.md) |
 | `seed` | `null` | Uses non-deterministic `Random.Default` | — |
 

--- a/docs/supported-types.md
+++ b/docs/supported-types.md
@@ -16,7 +16,7 @@ For types not listed here, register a [custom factory](custom-factories.md) or s
 | `Int` | `some<Int>()` | |
 | `Long` | `some<Long>()` | |
 | `Double` | `some<Double>()` | |
-| `Float` | `some<Float>()` | |
+| `Float` | `some<Float>()` | See [FloatStrategy](configuration/float-strategy.md) |
 | `Boolean` | `some<Boolean>()` | |
 | `Char` | `some<Char>()` | |
 | `Byte` | `some<Byte>()` | |

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,7 +13,8 @@ nav = [
       "configuration/index.md" ,
       "configuration/nullable-strategy.md",
       "configuration/string-strategy.md",
-      "configuration/collection-strategy.md"
+      "configuration/collection-strategy.md",
+      "configuration/float-strategy.md"
     ] },
   "supported-types.md",
   "custom-factories.md",


### PR DESCRIPTION
## Summary

Introduces a `FloatStrategy` so users can constrain the range of randomly generated `Float` values during fixture generation. Until now, `FloatResolver` always called `random.nextFloat()`, producing values in `[0.0, 1.0)` with no way to widen, shift, or pin the range without writing a custom resolver or factory.

This follows the same pattern as `CollectionStrategy`: a data class wrapping a `ClosedFloatingPointRange<Float>` with input validation, a `companion object default`, and a corresponding resolver update that consumes the active strategy via `StrategyProvider`. The default range `0.0f..1.0f` preserves the current behavior of `FloatResolver` to avoid a breaking change for existing users. A secondary constructor `FloatStrategy(fixed: Float)` is provided as a convenience for callers who want to pin generation to a single value.

Closes #69.

### What changed

- **New** `core/src/main/kotlin/dev/appoutlet/some/config/FloatStrategy.kt` — data class with primary constructor `FloatStrategy(range: ClosedFloatingPointRange<Float> = 0.0f..1.0f)`, secondary constructor `FloatStrategy(fixed: Float)`, validation that throws `IllegalArgumentException` when `range.start > range.endInclusive` (zero-width ranges allowed), and a `companion object` exposing `FloatStrategy.default`.
- **Updated** `FloatResolver` to accept a `StrategyProvider` and produce values within the configured range. Zero-width ranges return the fixed value directly; non-zero-width ranges use `start + random.nextFloat() * (endInclusive - start)` (exclusive end, matching `random.nextDouble(from, until)` semantics).
- **Updated** `SomeConfig.buildResolvers()` to wire `FloatResolver(strategyProvider, random)`.
- **Updated** KDoc in `Strategy.kt` and `SomeConfigBuilder.kt` to list `FloatStrategy` alongside the other built-in strategies.
- **New** `FloatStrategyTest` covering default range, validation of inverted ranges, zero-width behavior, and secondary constructor equivalence.
- **Updated** `FloatResolverTest` to cover the new constructor signature, default range, custom range, negative range, fixed value, zero-width range, and `SomeConfig` integration.
- **New** `docs/configuration/float-strategy.md` documenting configuration, fixed-value constructor, default, affected types, and validation. Linked from the configuration index defaults table, the `supported-types.md` `Float` row, and added to the `zensical.toml` Configuration nav.

## Checklist
- [x] Tests were added or updated when needed
- [x] Documentation was updated when needed